### PR TITLE
Upping marathon app auth timeout from 300 seconds to 600 seconds

### DIFF
--- a/builtin/credential/marathon/path_login.go
+++ b/builtin/credential/marathon/path_login.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	StartupThresholdSeconds = time.Second * 300
+	StartupThresholdSeconds = time.Second * 600
 )
 
 func pathLogin(b *backend) *framework.Path {


### PR DESCRIPTION
**ISSUE**: https://github.com/Banno/scala-libraries/issues/56

This doesn't close the issue above, but we suspect it may help some of the errors we are seeing when apps restart and don't auth in time.